### PR TITLE
Add new command, new functionality, and bugfix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Available commands
    sha256sum, completed, no
    sha512sum, completed, no
    true, completed, yes
-   uniq, not yet, no, `-c` is not implemented yet
+   uniq, completed, no
    rm, completed, no
    rmdir, completed, no
    which, completed, no

--- a/applets.go
+++ b/applets.go
@@ -35,6 +35,7 @@ import (
 	"github.com/shirou/toybox/applets/sha256sum"
 	"github.com/shirou/toybox/applets/sha512sum"
 	"github.com/shirou/toybox/applets/sleep"
+	"github.com/shirou/toybox/applets/sort"
 	"github.com/shirou/toybox/applets/tr"
 	"github.com/shirou/toybox/applets/true"
 	"github.com/shirou/toybox/applets/uniq"
@@ -85,6 +86,7 @@ func init() {
 		"uuidgen":   uuidgen.Main,
 		"rm":        rm.Main,
 		"rmdir":     rmdir.Main,
+		"sort":      sort.Main,
 		"tr":        tr.Main,
 		"yes":       yes.Main,
 		"wc":        wc.Main,

--- a/applets/head/head_test.go
+++ b/applets/head/head_test.go
@@ -9,27 +9,59 @@ import (
 )
 
 func TestBytes(t *testing.T) {
-	opt := &Option{
-		bytes: 23,
-	}
-	f, _ := os.Open("head_test.go")
-	w := new(bytes.Buffer)
-	head(w, f, opt)
-	assert.Equal(t, `package head
-
-import (
-`, w.String())
+	out := new(bytes.Buffer)
+	out.Grow(25)
+	assert.Nil(t, head(out, OpenRequiredFile("testdata/loremipsum.txt", t), &Option{bytes: 23}))
+	assert.Equal(t, testBytesExpectedResult, out.String())
 }
 
 func TestLines(t *testing.T) {
-	opt := &Option{
-		lines: 3,
-	}
-	f, _ := os.Open("head_test.go")
-	w := new(bytes.Buffer)
-	head(w, f, opt)
-	assert.Equal(t, `package head
-
-import (
-`, w.String())
+	out := new(bytes.Buffer)
+	out.Grow(250)
+	assert.Nil(t, head(out, OpenRequiredFile("testdata/loremipsum.txt", t), &Option{lines: 3}))
+	assert.Equal(t, testLinesExpectedResult, out.String())
 }
+
+func TestHeadNegativeLines(t *testing.T) {
+	out := new(bytes.Buffer)
+	out.Grow(550)
+	assert.Nil(t, head(out, OpenRequiredFile("testdata/loremipsum.txt", t), &Option{lines: -3}))
+	assert.Equal(t, testHeadNegativeLinesExpectedResult, out.String())
+}
+
+func TestHeadNegativeBytes(t *testing.T) {
+	out := new(bytes.Buffer)
+	out.Grow(600)
+	assert.Nil(t, head(out, OpenRequiredFile("testdata/loremipsum.txt", t), &Option{bytes: -175}))
+	assert.Equal(t, testHeadNegativeBytesExpectedResult, out.String())
+}
+
+func OpenRequiredFile(path string, t *testing.T) *os.File {
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("cannot open required file '%s': %s", path, err.Error())
+	}
+	return f
+}
+
+const testBytesExpectedResult = "Lorem ipsum dolor sit a"
+const testLinesExpectedResult = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eleifend, velit
+sed pulvinar tincidunt, nulla ante gravida massa, non vulputate mauris ex ac
+velit. Mauris vehicula ipsum ut lobortis tristique. Curabitur vel neque et eros
+`
+const testHeadNegativeLinesExpectedResult = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eleifend, velit
+sed pulvinar tincidunt, nulla ante gravida massa, non vulputate mauris ex ac
+velit. Mauris vehicula ipsum ut lobortis tristique. Curabitur vel neque et eros
+dapibus vehicula. Nulla lectus tellus, molestie ut cursus at, feugiat gravida
+risus. Nulla tincidunt est sed arcu tristique, eu convallis massa sodales.
+Pellentesque ornare eros nec ex elementum feugiat. Nulla condimentum lectus
+ipsum, id lacinia ex feugiat eu. Vivamus arcu arcu, sollicitudin id aliquam ut,
+`
+const testHeadNegativeBytesExpectedResult = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eleifend, velit
+sed pulvinar tincidunt, nulla ante gravida massa, non vulputate mauris ex ac
+velit. Mauris vehicula ipsum ut lobortis tristique. Curabitur vel neque et eros
+dapibus vehicula. Nulla lectus tellus, molestie ut cursus at, feugiat gravida
+risus. Nulla tincidunt est sed arcu tristique, eu convallis massa sodales.
+Pellentesque ornare eros nec ex elementum feugiat. Nulla condimentum lectus
+ipsum, id lacinia ex feugiat eu. Vivamus arcu arcu, sollicitudin id aliquam ut,
+luctus id erat. Nunc diam`

--- a/applets/head/testdata/loremipsum.txt
+++ b/applets/head/testdata/loremipsum.txt
@@ -1,0 +1,10 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eleifend, velit
+sed pulvinar tincidunt, nulla ante gravida massa, non vulputate mauris ex ac
+velit. Mauris vehicula ipsum ut lobortis tristique. Curabitur vel neque et eros
+dapibus vehicula. Nulla lectus tellus, molestie ut cursus at, feugiat gravida
+risus. Nulla tincidunt est sed arcu tristique, eu convallis massa sodales.
+Pellentesque ornare eros nec ex elementum feugiat. Nulla condimentum lectus
+ipsum, id lacinia ex feugiat eu. Vivamus arcu arcu, sollicitudin id aliquam ut,
+luctus id erat. Nunc diam lacus, euismod sit amet ex vel, egestas posuere odio.
+Cras elit eros, rhoncus a dolor non, laoreet faucibus risus. Curabitur eget
+elementum mauris. Donec ut tristique neque.

--- a/applets/sort/sort.go
+++ b/applets/sort/sort.go
@@ -2,15 +2,39 @@ package sort
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"io"
 	"os"
 	"sort"
 )
 
+type Option struct {
+	Help bool
+}
+
 const binaryName = "sort"
 
+func CreateFlagSet() (*flag.FlagSet, *Option) {
+	ret := flag.NewFlagSet(binaryName, flag.ExitOnError)
+	ret.Usage = func() {
+		fmt.Println(binaryName)
+		ret.PrintDefaults()
+	}
+	
+	var opt Option
+	ret.BoolVar(&opt.Help, "help", false, "display this help and exit")
+	return ret, &opt
+}
+
 func Main(stdout io.Writer, args []string) error {
+	flagSet, opt := CreateFlagSet()
+	flagSet.Parse(args)
+	if opt.Help {
+		flagSet.Usage()
+		return nil
+	}
+
 	lines := make([]string, 0)
 	s := bufio.NewScanner(os.Stdin)
 	for s.Scan() {

--- a/applets/sort/sort.go
+++ b/applets/sort/sort.go
@@ -1,0 +1,45 @@
+package sort
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+)
+
+const binaryName = "sort"
+
+func Main(stdout io.Writer, args []string) error {
+	lines := make([]string, 0)
+	s := bufio.NewScanner(os.Stdin)
+	for s.Scan() {
+		lines = append(lines, s.Text())
+	}
+	sort.Slice(lines, func(i, j int) bool {
+		s1 := lines[i]
+		s2 := lines[j]
+		minLength := len(s1)
+		if len(s2) < minLength {
+			minLength = len(s2)
+		}
+
+		for k := 0; k < minLength; k++ {
+			c1 := s1[k]
+			c2 := s2[k]
+			if c1 < c2 {
+				return true
+			} else if c1 > c2 {
+				return false
+			}
+		}
+		return len(s1) < len(s2)
+	})
+
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(stdout, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/applets/uniq/uniq.go
+++ b/applets/uniq/uniq.go
@@ -109,6 +109,9 @@ func uniq(in io.Reader, out io.Writer, opt *Option) error {
 
 func Print(s string, repetitions int, opt *Option) {
 	if (repetitions == 0 && !opt.repeated) || (repetitions != 0 && !opt.unique) {
+		if opt.count {
+			fmt.Printf("      %d ", repetitions+1)
+		}
 		fmt.Println(s)
 	}
 }

--- a/applets/uniq/uniq.go
+++ b/applets/uniq/uniq.go
@@ -81,40 +81,34 @@ func Main(stdout io.Writer, args []string) error {
 
 func uniq(in io.Reader, out io.Writer, opt *Option) error {
 	s := bufio.NewScanner(in)
-	var count int
-	var dup bool
+	var repetitions int
+	var isRepeated bool
 
 	// read first line as last line
 	s.Scan()
 	last := s.Text()
 
-	for s.Scan() {
+	for ; s.Scan(); last = s.Text() {
 		if opt.ignoreCase {
-			dup = strings.EqualFold(last, s.Text())
+			isRepeated = strings.EqualFold(last, s.Text())
 		} else {
-			dup = last == s.Text()
+			isRepeated = last == s.Text()
 		}
-		if dup {
-			if opt.repeated {
-				if opt.count {
-					fmt.Fprintf(out, "%-10d %s\n", count, last)
-				} else {
-					fmt.Fprintln(out, last)
-				}
-			}
+
+		if !isRepeated {
+			Print(last, repetitions, opt)
+			repetitions = 0
 		} else {
-			if opt.unique {
-				if opt.count {
-					fmt.Fprintf(out, "%-10d %s\n", count, last)
-				} else {
-					fmt.Fprintln(out, last)
-				}
-			}
-			count = 0
+			repetitions++
 		}
-		count += 1
-		last = s.Text()
 	}
+	Print(last, repetitions, opt)
 
 	return nil
+}
+
+func Print(s string, repetitions int, opt *Option) {
+	if (repetitions == 0 && !opt.repeated) || (repetitions != 0 && !opt.unique) {
+		fmt.Println(s)
+	}
 }

--- a/applets/uniq/uniq.go
+++ b/applets/uniq/uniq.go
@@ -95,11 +95,11 @@ func uniq(in io.Reader, out io.Writer, opt *Option) error {
 			isRepeated = last == s.Text()
 		}
 
-		if !isRepeated {
+		if isRepeated {
+			repetitions++
+		} else {
 			Print(last, repetitions, opt)
 			repetitions = 0
-		} else {
-			repetitions++
 		}
 	}
 	Print(last, repetitions, opt)

--- a/applets/uniq/uniq.go
+++ b/applets/uniq/uniq.go
@@ -110,7 +110,7 @@ func uniq(in io.Reader, out io.Writer, opt *Option) error {
 func Print(s string, repetitions int, opt *Option) {
 	if (repetitions == 0 && !opt.repeated) || (repetitions != 0 && !opt.unique) {
 		if opt.count {
-			fmt.Printf("      %d ", repetitions+1)
+			fmt.Printf("% 7d ", repetitions+1)
 		}
 		fmt.Println(s)
 	}


### PR DESCRIPTION
- Command uniq had different behaviour (probably bug) to GNU coreutils uniq. Fixed.
- Add sort command. It consumes much more memory and much less disk than GNU coreutils sort, but it works, and these considerations are tradeoffs (most computers will benefit from RAM speed, but some older / embedded computer processing lots of data will probably hang due to lack of memory)
- Add functionality for negative values in the head command (aka FEATURE_FANCY_HEAD in BusyBox)